### PR TITLE
Maintenance_v5.6.2 (stub bot)

### DIFF
--- a/tasks/maintenance/bots/stub.py
+++ b/tasks/maintenance/bots/stub.py
@@ -108,8 +108,15 @@ class Stub:
         for wikilink in parsed.wikilinks:
             tem_text = tem_text.replace(str(wikilink), str(wikilink.title))
 
+        # remove tables like this "{| |}"
+        tem_text = re.sub(r"{|\|[.|\w|\W]*?\|}", "", tem_text)
+
+        # remove numbers in string"
+        tem_text = re.sub(r"\d+", "", tem_text)
+
         # get counts of words
         result = len(re.findall(r'\w+', tem_text))
+        self.count_words = result
         if result >= 500:
             # start remove template
             status = False

--- a/tasks/maintenance/module.py
+++ b/tasks/maintenance/module.py
@@ -134,7 +134,7 @@ def process_article(site, cursor, conn, id, title, thread_number):
                         ]
                         if page.exists() and (not page.isRedirectPage()):
                             text = page.text
-                            summary = "بوت:صيانة V5.6.1"
+                            summary = "بوت:صيانة V5.6.2"
                             pipeline = Pipeline(page, text, summary, steps, extra_steps)
                             processed_text, processed_summary = pipeline.process()
                             # write processed text back to the page


### PR DESCRIPTION
- حذف الارقام من النص 
- حذف الجدوال من النص التي علي شاكلة 

```

{| cellpadding="12" cellspacing="10" class="wikitable sortable" style="border: 3px solid rgb(204, 204, 204); background: rgb(204, 204, 204); margin-bottom: 10px;"
!التاريخ
!عدد القتلى
!الفرع
!سبب الوفاة
!المُهاجِم
!الموقع
|-
|28 أغسطس 2016
|1
|القوات البرية
|إطلاق ناري
|قوات سوريا الديمقراطية
|محافظة حلبTurkish soldier killed in Syria attack, Kurdish militia blamed | Daily Mail Online 
|-
|}
```