### PR TITLE
V1.4.2

### DIFF
--- a/database/engine.py
+++ b/database/engine.py
@@ -31,5 +31,5 @@ port = config.get('mysql', 'port')
 database = config.get('mysql', 'database')
 
 # Create the database engine
-engine = create_engine(f'mysql+pymysql://{username}:{password}@{host}:{port}/{database}')
+engine = create_engine(f'mysql+pymysql://{username}:{password}@{host}:{port}/{database}',echo=False)
 

--- a/database/helpers.py
+++ b/database/helpers.py
@@ -1,3 +1,6 @@
+import datetime
+
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from database.models import Page, TaskName, Status
@@ -14,21 +17,26 @@ def get_articles(session, thread_number, pages_type):
     if thread_number == 1:
         thread_number = 0
 
+    now = func.now()
+
     query1 = session.query(Page.id, Page.title, Page.thread_number). \
         filter_by(status=Status.PENDING, task_name=pages_type, thread_number=1). \
-        order_by(Page.create_date). \
+        filter(Page.update_date < now). \
+        order_by(Page.update_date). \
         limit(200).offset(thread_number)
-
     query2 = session.query(Page.id, Page.title, Page.thread_number). \
         filter_by(status=Status.PENDING, task_name=pages_type, thread_number=2). \
-        order_by(Page.create_date). \
+        filter(Page.update_date < now). \
+        order_by(Page.update_date). \
         limit(200).offset(thread_number)
 
     query3 = session.query(Page.id, Page.title, Page.thread_number). \
         filter_by(status=Status.PENDING, task_name=pages_type, thread_number=3). \
-        order_by(Page.create_date). \
+        filter(Page.update_date < now). \
+        order_by(Page.update_date). \
         limit(200).offset(thread_number)
 
     yield from query1.all()
     yield from query2.all()
     yield from query3.all()
+

--- a/database/helpers.py
+++ b/database/helpers.py
@@ -40,3 +40,15 @@ def get_articles(session, thread_number, pages_type):
     yield from query2.all()
     yield from query3.all()
 
+
+def get_page_count(session, pages_type):
+
+    now = func.now()
+
+    query1 = session.query(func.count(Page.id)). \
+        filter_by(status=Status.PENDING, task_name=pages_type). \
+        filter(Page.update_date < now)
+
+    count = query1.scalar()
+
+    return count

--- a/tasks/maintenance/check.py
+++ b/tasks/maintenance/check.py
@@ -1,10 +1,12 @@
 import logging
 import threading
+import time
+
 import pywikibot
 from sqlalchemy.orm import Session
 
 from database.engine import engine
-from database.helpers import get_articles
+from database.helpers import get_articles, get_page_count
 from module import ProcessArticle
 from database.models import TaskName
 
@@ -14,10 +16,12 @@ def read(thread_number):
         print(thread_number)
         site = pywikibot.Site()
         with Session(engine) as session:
+
             for row in get_articles(session, thread_number, pages_type=TaskName.MAINTENANCE):
                 process_article = ProcessArticle(site=site, session=session, id=row[0], title=row[1],
                                                  thread_number=thread_number)
                 process_article.start()
+
 
     except Exception as e:
         logging.error("Error occurred while adding pages to the database.")
@@ -42,7 +46,15 @@ def run_threads():
 
 
 def main():
-    run_threads()
+    need_to_sleep = True
+    with Session(engine) as session:
+        need_to_sleep = get_page_count(session, pages_type=TaskName.MAINTENANCE)
+    if not bool(need_to_sleep):
+        # sleep for 10 mint To prevent  it from run again
+        print("sleep for 10 mint To prevent  it from run again")
+        time.sleep(600)
+    else:
+        run_threads()
     return 0
 
 

--- a/tasks/maintenance/module.py
+++ b/tasks/maintenance/module.py
@@ -10,7 +10,7 @@ from core.utils.file import File
 from core.utils.helpers import check_status, prepare_str, check_edit_age
 from core.utils.pipeline import Pipeline
 from core.utils.wikidb import Database
-from database.models import Page, Status, TaskName
+from database.models import Page, Status as Model_Status
 
 from tasks.maintenance.bots.dead_end import DeadEnd
 from tasks.maintenance.bots.has_categories import HasCategories
@@ -151,7 +151,7 @@ class ProcessArticle:
             # get page object
             self.page = pywikibot.Page(self.site, self.title)
             # Check if the page has already been processed
-            self.page_query = self.session.query(Page).filter_by(id=self.id, status=Status.PENDING).one_or_none()
+            self.page_query = self.session.query(Page).filter_by(id=self.id, status=Model_Status.PENDING).one_or_none()
 
 
             if self.page is None:
@@ -159,7 +159,7 @@ class ProcessArticle:
             else:
                 if self.page_query is not None:
                     # Update the status of the page to indicate that it is being processed
-                    self.page_query.status = Status.RECEIVED
+                    self.page_query.status = Model_Status.RECEIVED
                     self.session.commit()
 
                     if self.page.exists() and (not self.page.isRedirectPage()):
@@ -211,6 +211,6 @@ class ProcessArticle:
         if self.page_query is not None:
             delta = datetime.timedelta(hours=hours)
             new_date = datetime.datetime.now() + delta
-            self.page_query.status = Status.PENDING
+            self.page_query.status = Model_Status.PENDING
             self.page_query.date = new_date
             self.session.commit()

--- a/tasks/maintenance/module.py
+++ b/tasks/maintenance/module.py
@@ -76,14 +76,23 @@ FROM (
         yield title
 
 
-def get_skip_pages():
+# todo: call it from bot task
+def get_skip_pages(name_of_page = None):
     home_path = os.path.expanduser("~")
     file = File(script_dir=home_path)
     file_path = prepare_str('maintenance_skip.txt')
     file.set_stub_path(file_path)
     file.get_json_content()
     templates = json.loads(file.contents)
-    return templates
+    if name_of_page is None:
+        return templates
+    else:
+        found = False
+        for page in templates:
+            if prepare_str(page) == prepare_str(name_of_page):
+                found = True
+                break
+        return  found
 
 
 class PipelineTasks:
@@ -164,8 +173,7 @@ class ProcessArticle:
 
                     if self.page.exists() and (not self.page.isRedirectPage()):
                         # if status true can edit
-                        if check_edit_age(page=self.page):
-
+                        if check_edit_age(page=self.page) and not get_skip_pages(name_of_page=self.page.title(with_ns=False)):
                             try:
 
                                 self.pipeline = Pipeline(self.page, self.page.text, TASK_SUMMARY, PipelineTasks.steps,

--- a/tasks/maintenance/module.py
+++ b/tasks/maintenance/module.py
@@ -212,5 +212,5 @@ class ProcessArticle:
             delta = datetime.timedelta(hours=hours)
             new_date = datetime.datetime.now() + delta
             self.page_query.status = Model_Status.PENDING
-            self.page_query.date = new_date
+            self.page_query.update_date = new_date
             self.session.commit()

--- a/tasks/webcite/check.py
+++ b/tasks/webcite/check.py
@@ -1,11 +1,12 @@
 import logging
 import threading
+import time
 
 import pywikibot
 from sqlalchemy.orm import Session
 
 from database.engine import engine
-from database.helpers import get_articles
+from database.helpers import get_articles, get_page_count
 from database.models import TaskName
 from tasks.webcite.module import  ProcessArticle
 from tasks.webcite.modules.request_limiter import RequestLimiter
@@ -16,10 +17,18 @@ def read(thread_number):
         print(thread_number)
         limiter = RequestLimiter()
         site = pywikibot.Site()
+        need_to_sleep = True
+
         with Session(engine) as session:
             for row in get_articles(session, thread_number,pages_type=TaskName.WEBCITE):
+                need_to_sleep = False
                 process_article = ProcessArticle(site=site,session=session, id=row[0], title=row[1], thread_number=thread_number, limiter=limiter)
                 process_article.start()
+
+        if not need_to_sleep:
+            # sleep 10 min cos now rows found in db now
+            print("sleep 10 min cos now rows found in db now ")
+            time.sleep(600)
 
     except Exception as e:
         logging.error("Error occurred while adding pages to the database.")
@@ -43,11 +52,21 @@ def run_threads():
         thread.join()
 
 
+
 def main():
-    limiter = RequestLimiter()
-    run_threads()
-    limiter.clear_old_requests()
+    need_to_sleep = True
+    with Session(engine) as session:
+        need_to_sleep = get_page_count(session, pages_type=TaskName.WEBCITE)
+    if not bool(need_to_sleep):
+        # sleep for 10 mint To prevent  it from run again
+        print("sleep for 10 mint To prevent  it from run again")
+        time.sleep(600)
+    else:
+        limiter = RequestLimiter()
+        run_threads()
+        limiter.clear_old_requests()
     return 0
+
 
 
 if __name__ == "__main__":

--- a/tasks/webcite/module.py
+++ b/tasks/webcite/module.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 import pywikibot
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from core.utils.helpers import check_status, check_edit_age
@@ -105,5 +106,5 @@ class ProcessArticle:
             delta = datetime.timedelta(hours=hours)
             new_date = datetime.datetime.now() + delta
             self.page_query.status = Model_Status.PENDING
-            self.page_query.date = new_date
+            self.page_query.update_date = new_date
             self.session.commit()

--- a/tasks/webcite/module.py
+++ b/tasks/webcite/module.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from core.utils.helpers import check_status, check_edit_age
 from core.utils.wikidb import Database
-from database.models import Page, Status
+from database.models import Page, Status as Model_Status
 from tasks.webcite.modules.parsed import Parsed
 from tasks.webcite.modules.request_limiter import RequestLimiter
 
@@ -45,18 +45,14 @@ class ProcessArticle:
             # get page object
             self.page = pywikibot.Page(self.site, self.title)
             # Check if the page has already been processed
-            self.page_query = self.session.query(Page).filter_by(id=self.id, status=Status.PENDING).one_or_none()
-
-            # Update the status of the page to indicate that it is being processed
-            self.page_query.status = Status.RECEIVED
-            self.session.commit()
+            self.page_query = self.session.query(Page).filter_by(id=self.id, status=Model_Status.PENDING).one_or_none()
 
             if self.page is None:
                 self._delete_page()
             else:
                 if self.page_query is not None:
                     # Update the status of the page to indicate that it is being processed
-                    self.page_query.status = Status.RECEIVED
+                    self.page_query.status = Model_Status.RECEIVED
                     self.session.commit()
 
                     if self.page.exists() and (not self.page.isRedirectPage()):
@@ -108,6 +104,6 @@ class ProcessArticle:
         if self.page_query is not None:
             delta = datetime.timedelta(hours=hours)
             new_date = datetime.datetime.now() + delta
-            self.page_query.status = Status.PENDING
+            self.page_query.status = Model_Status.PENDING
             self.page_query.date = new_date
             self.session.commit()


### PR DESCRIPTION
- جعل مهمة الصيانه والارشفه لا تعمل علي الصفحات التي تحتوي علي قيمة اكبر من الوقت الحالي في عمود update_date لحل مشكله تقليل ضربات مرشح الاساءة
- جعل مهمة الصيانه والارشفه لا تعمل بشكل تلقائي عندما لا يوجد صفحات  متوفر للعمل عليها وجعل البوت يتوقف لمده ١٠ دقائق حتي تكون مهمة جلب الصفحات الجديدة بدات لاكمال العمل وذلك لحل مشكله تشغيل المهمام دون وجود صفحات لتقليل الضغط علي السيرفر 
- تم اضافة get_skip_pages مره اخري الي بوت الصيانه وذلك بعد حذفها بالخطا اثناء عمليات الدمج الماضية 
