### PR TITLE
v2.2.0 ويكيبيديا:إخطار الإداريين/أسماء مستخدمين للفحص

### DIFF
--- a/tasks/check_usernames/check/check.py
+++ b/tasks/check_usernames/check/check.py
@@ -41,7 +41,7 @@ def main(*args: str) -> int:
             check_page = Check(site=site, page_title=check_page_title)
             check_page.load()
             if check_page.check():
-                # create only if check page is true
+                # create cat only if check page is true
                 # https://ar.wikipedia.org/w/index.php?title=%D9%86%D9%82%D8%A7%D8%B4_%D9%88%D9%8A%D9%83%D9%8A%D8%A8%D9%8A%D8%AF%D9%8A%D8%A7:%D8%A5%D8%AE%D8%B7%D8%A7%D8%B1_%D8%A7%D9%84%D8%A5%D8%AF%D8%A7%D8%B1%D9%8A%D9%8A%D9%86/%D8%A3%D8%B3%D9%85%D8%A7%D8%A1_%D9%85%D8%B3%D8%AA%D8%AE%D8%AF%D9%85%D9%8A%D9%86_%D9%84%D9%84%D9%81%D8%AD%D8%B5&oldid=62429509#17_%D9%85%D8%A7%D9%8A%D9%88!
                 category = Category(site=site)
                 category.create()
@@ -68,7 +68,7 @@ def main(*args: str) -> int:
                 file.get_file_content()
                 content = file.contents
 
-                load_obj = Load(content_text=content, names=names, page_title=page_title, site=site)
+                load_obj = Load(content_text=content, names=[], page_title=page_title, site=site, users=[])
                 load_obj.load_page().build_table().save_page()
         else:
             print("check wiki site")

--- a/tasks/check_usernames/check/check.py
+++ b/tasks/check_usernames/check/check.py
@@ -37,13 +37,15 @@ def main(*args: str) -> int:
         if check_status("مستخدم:LokasBot/إخطار الإداريين/أسماء مستخدمين للفحص"):
             site = pywikibot.Site()
 
-            category = Category(site=site)
-            category.create()
-
             check_page_title = "ويكيبيديا:إخطار الإداريين/أسماء مستخدمين للفحص/تشغيل البوت"
             check_page = Check(site=site, page_title=check_page_title)
             check_page.load()
             if check_page.check():
+                # create only if check page is true
+                # https://ar.wikipedia.org/w/index.php?title=%D9%86%D9%82%D8%A7%D8%B4_%D9%88%D9%8A%D9%83%D9%8A%D8%A8%D9%8A%D8%AF%D9%8A%D8%A7:%D8%A5%D8%AE%D8%B7%D8%A7%D8%B1_%D8%A7%D9%84%D8%A5%D8%AF%D8%A7%D8%B1%D9%8A%D9%8A%D9%86/%D8%A3%D8%B3%D9%85%D8%A7%D8%A1_%D9%85%D8%B3%D8%AA%D8%AE%D8%AF%D9%85%D9%8A%D9%86_%D9%84%D9%84%D9%81%D8%AD%D8%B5&oldid=62429509#17_%D9%85%D8%A7%D9%8A%D9%88!
+                category = Category(site=site)
+                category.create()
+
                 check_page.reload()
                 read_users_page_title = "ويكيبيديا:إخطار الإداريين/أسماء مستخدمين للفحص"
                 # read_users_page_title= "مستخدم:لوقا/ملعب 20"

--- a/tasks/check_usernames/check/modules.py
+++ b/tasks/check_usernames/check/modules.py
@@ -72,7 +72,7 @@ class Category:
             self.cat_name = f"تصنيف:أسماء مستخدمين مخالفة مرشحة للمنع منذ {cat_date}"
             cat = pywikibot.Category(self.site, self.cat_name)
             cat.text = "{{تصنيف تهذيب شهري}}"
-            cat.save("بوت:فحص (إنشاء تصنيف صيانة) V2.1.0")
+            cat.save("بوت:فحص (إنشاء تصنيف صيانة) V2.2.0")
         except:
             print("failed to create category")
 

--- a/tasks/check_usernames/check/stub/load.txt
+++ b/tasks/check_usernames/check/stub/load.txt
@@ -1,0 +1,12 @@
+{{ويكيبيديا:إخطار الإداريين/أسماء مستخدمين للفحص/رسالة للإداري}}
+<div style="background: #E5E4E2; padding: 0.5em; -moz-border-radius: 0.3em; border-radius: 0.3em;">
+<center>
+'''حَدَّث BOT_USER_NAME هذه القائمة في :  BOT_TIME_NOW (ت ع م) '''
+{| class="wikitable sortable"
+!style="background-color:#808080" align="center"|الرقم!!style="background-color:#808080" align="center"|نسبة التنبؤ!!style="background-color:#808080" align="center"|المستخدم!!style="background-color:#808080" align="center"|حالة المراجعة!!style="background-color:#808080" align="center"|السبب
+|-
+BOT_TABLE_BODY
+|}
+</div>
+</center>
+[[تصنيف:إدارة ويكيبيديا]]

--- a/tasks/check_usernames/load/load.py
+++ b/tasks/check_usernames/load/load.py
@@ -136,7 +136,7 @@ class Load:
     def save_page(self):
         # start save page
         self.page.text = self.text
-        self.page.save("بوت:فحص V2.1.0")
+        self.page.save("بوت:فحص V2.2.0")
         return self
 
 


### PR DESCRIPTION
1. جعل التصنيف  اليوم لا يتم انشائها الا اذا كان هناك تبليغات للمستخدمين
2. افراغ الجدوال بعد عمليه الفحص