### PR TITLE
use revision_userindex instead of revision [distribute_medals_v1.4.0]

### DIFF
--- a/tasks/distribute_medals/data.py
+++ b/tasks/distribute_medals/data.py
@@ -2,253 +2,253 @@ list_of_distribute_medals = [
     {
         "number": 500,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 1000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 2000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 3000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 5000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 10000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 20000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 30000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 40000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 50000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 60000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 70000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 80000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 90000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 100000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 125000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 150000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 175000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 200000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 225000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 250000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 275000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },
     {
         "number": 300000,
         "query": """SELECT actor_name,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
-       (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) AS sum_yc,
+       (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) AS sum_tc
 FROM actor
-WHERE (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
-AND (SELECT COUNT(*) FROM revision WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
+WHERE (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp < START_DATE) < NUMBER_COUNT
+AND (SELECT COUNT(*) FROM revision_userindex WHERE rev_actor = actor_id AND rev_timestamp <= END_DATE) >= NUMBER_COUNT
 and actor_name not in (select REPLACE(pl_title, '_', ' ') from pagelinks where  pl_from = 7519882);""",
         "template_stub": "{{وسام تعديلات|NUMBER|-- SIGNATURE  {{safesubst:#وقت:G:i، j F Y}}  (ت ع م)|USERNAME}}"
     },

--- a/tasks/distribute_medals/module.py
+++ b/tasks/distribute_medals/module.py
@@ -302,7 +302,7 @@ class SendTemplate(Base):
                     # Save the edited page
                     print("start send to " + name)
                     talk_page.text = text
-                    summary = str("بوت:[[ويكيبيديا:توزيع أوسمة|توزيع أوسمة]] (NUMBER_COUNT تعديل) (v1.3.0)").replace(
+                    summary = str("بوت:[[ويكيبيديا:توزيع أوسمة|توزيع أوسمة]] (NUMBER_COUNT تعديل) (v1.4.0)").replace(
                         'NUMBER_COUNT', str(self.input_dict['number']))
                     # Save the page
                     talk_page.save(summary=summary,minor=False)


### PR DESCRIPTION
- استخدام جدوال revision_userindex بدلا من revision وذلك لان الاستعلام ياخذ وقد كبير جدا فينقطع الاتصال[ وايضا بسبب انه اسرع ](https://wikitech.wikimedia.org/wiki/Help:MySQL_queries#Alternative_Views)