### PR TITLE
maintenance_V5.10.0 add:remove template with \n

### DIFF
--- a/tasks/maintenance/bots/dead_end.py
+++ b/tasks/maintenance/bots/dead_end.py
@@ -58,6 +58,7 @@ class DeadEnd:
         for needed_template in self.templates:
             for template in self.parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:

--- a/tasks/maintenance/bots/has_categories.py
+++ b/tasks/maintenance/bots/has_categories.py
@@ -60,6 +60,7 @@ class HasCategories:
         for needed_template in self.templates:
             for template in parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:

--- a/tasks/maintenance/bots/orphan.py
+++ b/tasks/maintenance/bots/orphan.py
@@ -58,6 +58,7 @@ class Orphan:
         for needed_template in self.templates:
             for template in self.parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:

--- a/tasks/maintenance/bots/protection.py
+++ b/tasks/maintenance/bots/protection.py
@@ -81,6 +81,7 @@ class Protection:
         for needed_template in self.templates:
             for template in self.parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:

--- a/tasks/maintenance/bots/underlinked.py
+++ b/tasks/maintenance/bots/underlinked.py
@@ -62,6 +62,7 @@ class UnderLinked:
         for needed_template in self.templates:
             for template in self.parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:

--- a/tasks/maintenance/bots/unreferenced.py
+++ b/tasks/maintenance/bots/unreferenced.py
@@ -74,6 +74,7 @@ class Unreferenced:
         for needed_template in self.templates:
             for template in self.parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:

--- a/tasks/maintenance/bots/unreviewed_article.py
+++ b/tasks/maintenance/bots/unreviewed_article.py
@@ -1,5 +1,5 @@
-import wikitextparser as wtp
 import pywikibot
+import wikitextparser as wtp
 
 from core.utils.helpers import prepare_str
 
@@ -50,6 +50,7 @@ class UnreviewedArticle:
         for needed_template in self.templates:
             for template in parsed.templates:
                 if prepare_str(template.name) == prepare_str(needed_template):
+                    new_text = str(new_text).replace(str(template) + "\n", "")
                     new_text = str(new_text).replace(str(template), "")
 
         if new_text != self.text:


### PR DESCRIPTION
حل مشكلة 
"
أن البوت يترك سطر فارغ بعد إزالته لقوالب الصيانة من المقالات، مما يضطر الزملاء لإزالته يدويا لاحقًا، والأصل أن يزيل القالب مع السطر الجديد \n إن وجد
"
حسب طلب الزميل [مهند](https://ar.wikipedia.org/w/index.php?title=%D9%86%D9%82%D8%A7%D8%B4_%D8%A7%D9%84%D9%85%D8%B3%D8%AA%D8%AE%D8%AF%D9%85:%D9%84%D9%88%D9%82%D8%A7&oldid=65720902#%D8%A7%D8%B2%D8%A7%D9%84%D8%A9_%D9%82%D9%88%D8%A7%D9%84%D8%A8_%D8%A7%D9%84%D8%B5%D9%8A%D8%A7%D9%86%D8%A9)