### PR TITLE
Migrate archivebot from PHP to Python (tasks/archive_bot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,9 @@ dmypy.json
 .pyre/
 
 .idea
+
+# pywikibot local credentials and API cache
+user-config.py
+user-password.py
+apicache/
+*.lwp

--- a/tasks/archive_bot/PLAN.md
+++ b/tasks/archive_bot/PLAN.md
@@ -1,0 +1,181 @@
+# Archive Bot — PHP → Python Migration Plan
+
+Migrate the legacy PHP **archivebot** (Peachy framework, archived at
+https://github.com/LokasWiki/archivebot) into a Python task inside LokasBot:
+`tasks/archive_bot/`, following the project's clean-architecture conventions
+and running on pywikibot + Python 3.13.
+
+The bot archives old discussion threads from **Arabic Wikipedia user talk pages**
+(namespace 3) that transclude `{{أرشفة آلية}}` (Template:Auto archiving).
+
+---
+
+## 1. Source analysis (what the PHP bot does)
+
+Two files contain the whole logic:
+
+| PHP file | Python target |
+|---|---|
+| `script/MyScripts.php` | entry point + template scanning |
+| `script/Lib2.php` | `splitintosections()` + `doarchive()` core |
+
+### `MyScripts.php` flow
+1. `embeddedin("قالب:أرشفة آلية", 3, null)` → list user-talk pages (namespace 3)
+   that transclude the template.
+2. Skip pages whose title contains `/` (subpages).
+3. Skip pages with sysop-level `edit` protection.
+4. For each page: `readtemp($page, $name)`:
+   - parse `{{أرشفة آلية|...}}` params,
+   - if mode is `قسم` (by age) → `age = value * 24` hours,
+   - else (by size) → archive only when `page_length >= value * 1000` bytes,
+   - call `doarchive(...)`.
+5. `sleep(3)` between pages.
+
+### `Lib2.php` — `doarchive()` core
+1. Get latest revision + its text.
+2. Split text into level-2 sections (`splitintosections`).
+3. Walk history backward until a revision older than `age` hours is found;
+   that revision's text is the "old" snapshot.
+4. Split old snapshot into sections; drop old sections no longer present.
+5. Classify each current section:
+   - keep if it contains `{{لا للأرشفة}}` (do-not-archive),
+   - keep if it is new (not in old snapshot),
+   - archive if unchanged since the old snapshot (older than `age`),
+   - keep if `minkeep` would be violated,
+   - optional: enforce `maxsects` / `maxbytes`.
+6. Build archive page name: `archiveprefix + " " + counter` (e.g.
+   `نقاش المستخدم:لوقا/أرشيف 3`), using `prefixindex` to find the current max counter.
+7. Archive page header default:
+   ```
+   {{تصفح أرشيف|N}}
+   {{تمت الأرشفة}}
+   {{أرشيف صفحة رئيسية}}
+   ```
+8. Save the archive page first (`أرشفة … من [[page]]`), then the main page
+   (`أرشفة … إلى [[archive]]`); roll back the archive edit if the main-page edit fails.
+9. Update the trailing counter inside the `{{أرشفة آلية|...}}` template on the main page.
+
+### `{{أرشفة آلية}}` template contract (Arabic Wikipedia)
+
+Invocation format:
+
+```
+{{أرشفة آلية|<type>|<value>|<archive_prefix>|<counter>}}
+```
+
+| Param | Meaning |
+|---|---|
+| `1` (`type`) | `قسم` = archive by age, or `حجم` = archive by size |
+| `2` (`value`) | days (for `قسم`) or KB threshold (for `حجم`) |
+| `3` (`archive_prefix`) | archive page name prefix, e.g. `نقاش المستخدم:لوقا/أرشيف` |
+| `4` (`counter`) | current archive number (trailing digits); auto-updated by the bot |
+
+- Optional legacy flag `|عددي` / `|عددى` is stripped before parsing.
+- `{{لا للأرشفة}}` inside a section = do not archive that section.
+
+---
+
+## 2. Target architecture (clean architecture, matches existing tasks)
+
+```
+tasks/archive_bot/
+├── __init__.py
+├── config/
+│   ├── __init__.py
+│   ├── config_loader.py          # template name, edit summaries, headers, site
+│   └── settings.json             # externalized config
+├── domain/
+│   ├── __init__.py
+│   ├── entities/
+│   │   ├── __init__.py
+│   │   ├── archive_config.py     # parsed {{أرشفة آلية}} params
+│   │   ├── section.py            # wiki section (header + content)
+│   │   └── archive_result.py     # outcome of one page archiving
+│   ├── repositories/
+│   │   ├── __init__.py
+│   │   └── wiki_repository.py    # abstract interface (ABC)
+│   └── use_cases/
+│       ├── __init__.py
+│       ├── parse_archive_config.py   # template parser use case
+│       ├── split_sections.py         # wikitext → sections
+│       ├── decide_archive.py         # classify keep vs archive
+│       └── archive_page.py           # orchestrate the archiving
+├── data/
+│   ├── __init__.py
+│   └── pywikibot_wiki_repository.py  # pywikibot implementation
+├── presentation/
+│   ├── __init__.py
+│   └── wiki_operations.py        # wiring + site bootstrap
+└── main.py                       # entry point (main + argparse)
+```
+
+Tests mirror this under `tests/tasks/archive_bot/`.
+
+---
+
+## 3. PHP → Python mapping (key pywikibot equivalents)
+
+| PHP (Peachy) | Python (pywikibot) |
+|---|---|
+| `Peachy::newWiki("arwiki")` | `pywikibot.Site("ar", "wikipedia")` |
+| `$MyWiki->embeddedin($tpl, 3, null)` | `pywikibot.Page(site, tpl).embeddedin(namespace=3)` |
+| `$MyWiki->initPage($t)` | `pywikibot.Page(site, t)` |
+| `$page->get_text()` | `page.text` |
+| `$page->get_length()` | `len(page.text)` |
+| `$page->history(2000,'older',...)` | `page.revisions(total=..., reverse=False)` |
+| `$page->get_protection()` | `page.protection()` |
+| `$page->edit($text, $summary, true)` | `page.text = ...; page.save(summary)` |
+| `$MyWiki->prefixindex($prefix, 3, null)` | `site.allpages(prefix=..., namespace=3)` |
+
+---
+
+## 4. TODO checklist
+
+### Phase A — Scaffolding
+- [ ] A1. Create `tasks/archive_bot/` package skeleton (`__init__.py` files, subpackages per §2).
+- [ ] A2. Add `tests/tasks/archive_bot/` skeleton with a first smoke test.
+
+### Phase B — Pure domain logic (unit-testable, no network)
+- [ ] B1. `split_sections.py` — port `splitintosections()` to split wikitext into header + level-2 sections (handle `===`/`====` correctly, duplicate headers).
+- [ ] B2. `parse_archive_config.py` — parse `{{أرشفة آلية|...}}` (type/value/prefix/counter, strip `|عددي`), with validation and error reporting.
+- [ ] B3. `decide_archive.py` — port keep-vs-archive classification: `{{لا للأرشفة}}`, new-vs-unchanged, `minkeep`, `maxsects`/`maxbytes`, header transform.
+- [ ] B4. Entities: `ArchiveConfig`, `Section`, `ArchiveResult` dataclasses.
+
+### Phase C — Infrastructure (pywikibot)
+- [ ] C1. `pywikibot_wiki_repository.py` implementing `WikiRepository` (embeddedin, text, length, revisions, protection, prefixindex, save).
+- [ ] C2. `wiki_operations.py` presentation wiring + site bootstrap + logging.
+
+### Phase D — Orchestration
+- [ ] D1. `archive_page.py` use case — full `doarchive` flow: history walk, section diff, archive-page naming/counter, header injection, save order + rollback, counter update.
+- [ ] D2. `main.py` — scan namespace-3 pages, skip `/` subpages + sysop-protected, `sleep` throttle, `--dry-run` and `--page` flags, logging to file.
+
+### Phase E — Tests
+- [ ] E1. Unit tests for B1–B3 with real Arabic wikitext fixtures (25+ tests).
+- [ ] E2. Repository fake (in-memory) for D1 use-case tests (no network).
+- [ ] E3. Integration smoke test: `--page` + `--dry-run` against a sandbox page.
+
+### Phase F — Configuration & docs
+- [ ] F1. `config_loader.py` + `settings.json` (template name, summaries, header templates, site, throttle, limits).
+- [ ] F2. `README.md` for the task (usage, config, how it maps to the old PHP bot).
+
+### Phase G — Toolforge deployment (after local validation)
+- [ ] G1. `toolforge/jobs/archive_bot.sh` wrapper.
+- [ ] G2. Add cronjob entry (cronjobs YAML) with `python3.13` image.
+- [ ] G3. Switch the live job from the PHP tool to this Python task.
+
+---
+
+## 5. Migration notes / gotchas
+
+- **Use pywikibot's battle-tested algorithm** (`scripts/archivebot.py` upstream,
+  see `/tmp/archivebot_pywiki_reference.py`) as the reference; the PHP `doarchive`
+  is itself an old port of it. Prefer the correct behavior over replicating PHP quirks.
+- **`embeddedin` namespace is 3** (User talk) — keep that default, but make it
+  configurable so other talk namespaces can be added later.
+- **Archive page naming** uses a space + counter: `<prefix> <N>` (not a subpage `/N`).
+- **Save order matters**: write archive page first, then main page; on failure of
+  the second save, restore the archive page (the PHP bot does this).
+- **Counter update**: rewrite the trailing number inside the template via regex,
+  matching the old behavior.
+- **Don't break anything**: the new task is additive (`tasks/archive_bot/`) and
+  does not touch existing tasks; keep dependencies unchanged.

--- a/tasks/archive_bot/PLAN.md
+++ b/tasks/archive_bot/PLAN.md
@@ -132,31 +132,31 @@ Tests mirror this under `tests/tasks/archive_bot/`.
 ## 4. TODO checklist
 
 ### Phase A — Scaffolding
-- [ ] A1. Create `tasks/archive_bot/` package skeleton (`__init__.py` files, subpackages per §2).
-- [ ] A2. Add `tests/tasks/archive_bot/` skeleton with a first smoke test.
+- [x] A1. Create `tasks/archive_bot/` package skeleton (`__init__.py` files, subpackages per §2).
+- [x] A2. Add `tests/tasks/archive_bot/` skeleton with a first smoke test.
 
 ### Phase B — Pure domain logic (unit-testable, no network)
-- [ ] B1. `split_sections.py` — port `splitintosections()` to split wikitext into header + level-2 sections (handle `===`/`====` correctly, duplicate headers).
-- [ ] B2. `parse_archive_config.py` — parse `{{أرشفة آلية|...}}` (type/value/prefix/counter, strip `|عددي`), with validation and error reporting.
-- [ ] B3. `decide_archive.py` — port keep-vs-archive classification: `{{لا للأرشفة}}`, new-vs-unchanged, `minkeep`, `maxsects`/`maxbytes`, header transform.
-- [ ] B4. Entities: `ArchiveConfig`, `Section`, `ArchiveResult` dataclasses.
+- [x] B1. `split_sections.py` — port `splitintosections()` to split wikitext into header + level-2 sections (handle `===`/`====` correctly, duplicate headers).
+- [x] B2. `parse_archive_config.py` — parse `{{أرشفة آلية|...}}` (type/value/prefix/counter, strip `|عددي`), with validation and error reporting.
+- [x] B3. `decide_archive.py` — port keep-vs-archive classification: `{{لا للأرشفة}}`, new-vs-unchanged, `minkeep`, `maxsects`/`maxbytes`, header transform.
+- [x] B4. Entities: `ArchiveConfig`, `Section`, `ArchiveResult` dataclasses.
 
 ### Phase C — Infrastructure (pywikibot)
-- [ ] C1. `pywikibot_wiki_repository.py` implementing `WikiRepository` (embeddedin, text, length, revisions, protection, prefixindex, save).
-- [ ] C2. `wiki_operations.py` presentation wiring + site bootstrap + logging.
+- [x] C1. `pywikibot_wiki_repository.py` implementing `WikiRepository` (embeddedin, text, length, revisions, protection, prefixindex, save).
+- [x] C2. `wiki_operations.py` presentation wiring + site bootstrap + logging.
 
 ### Phase D — Orchestration
-- [ ] D1. `archive_page.py` use case — full `doarchive` flow: history walk, section diff, archive-page naming/counter, header injection, save order + rollback, counter update.
-- [ ] D2. `main.py` — scan namespace-3 pages, skip `/` subpages + sysop-protected, `sleep` throttle, `--dry-run` and `--page` flags, logging to file.
+- [x] D1. `archive_page.py` use case — full `doarchive` flow: history walk, section diff, archive-page naming/counter, header injection, save order + rollback, counter update.
+- [x] D2. `main.py` — scan namespace-3 pages, skip `/` subpages + sysop-protected, `sleep` throttle, `--dry-run` and `--page` flags, logging to file.
 
 ### Phase E — Tests
-- [ ] E1. Unit tests for B1–B3 with real Arabic wikitext fixtures (25+ tests).
-- [ ] E2. Repository fake (in-memory) for D1 use-case tests (no network).
+- [x] E1. Unit tests for B1–B3 with real Arabic wikitext fixtures (37 tests).
+- [x] E2. Repository fake (in-memory) for D1 use-case tests (no network).
 - [ ] E3. Integration smoke test: `--page` + `--dry-run` against a sandbox page.
 
 ### Phase F — Configuration & docs
-- [ ] F1. `config_loader.py` + `settings.json` (template name, summaries, header templates, site, throttle, limits).
-- [ ] F2. `README.md` for the task (usage, config, how it maps to the old PHP bot).
+- [x] F1. `config_loader.py` + `settings.json` (template name, summaries, header templates, site, throttle, limits).
+- [x] F2. `README.md` for the task (usage, config, how it maps to the old PHP bot).
 
 ### Phase G — Toolforge deployment (after local validation)
 - [ ] G1. `toolforge/jobs/archive_bot.sh` wrapper.

--- a/tasks/archive_bot/README.md
+++ b/tasks/archive_bot/README.md
@@ -1,0 +1,82 @@
+# Archive Bot (tasks/archive_bot)
+
+أرشفة آلية لنقاشات صفحات نقاش المستخدمين في ويكيبيديا العربية.
+
+A Python migration of the legacy PHP **archivebot** (Peachy framework,
+archived at https://github.com/LokasWiki/archivebot). The bot archives old
+discussion threads from Arabic Wikipedia **user talk pages** (namespace 3)
+that transclude `{{أرشفة آلية}}`.
+
+## How it works
+
+1. Finds every user-talk page that transcludes `{{أرشفة آلية}}`.
+2. Skips subpages (titles containing `/`) and sysop-protected pages.
+3. Parses the template parameters with `wikitextparser`:
+
+   ```
+   {{أرشفة آلية|<type>|<value>|<archive_prefix_with_counter>}}
+   ```
+
+   | Param | Meaning |
+   |---|---|
+   | `قسم` | archive by age — `value` = days |
+   | `حجم` | archive by size — `value` = kilobytes |
+   | prefix | e.g. `نقاش المستخدم:Example/أرشيف 6` (trailing digits = counter) |
+
+4. Splits the page into level-2 sections and compares them against a
+   snapshot from `age` hours/days ago.
+5. Moves sections whose content is unchanged (i.e. had no activity for the
+   threshold) to the archive page `<prefix> <counter>`.
+6. Keeps sections marked `{{لا للأرشفة}}` and new/edited sections.
+7. Writes the archive page first, then the talk page; on failure of the
+   second write it rolls back the archive edit.
+8. Updates the archive counter inside the template.
+
+## Usage
+
+```bash
+# Preview without saving
+uv run python -m tasks.archive_bot.main --dry-run
+
+# Archive a single page (dry run)
+uv run python -m tasks.archive_bot.main --page "نقاش المستخدم:Example" --dry-run
+
+# Archive a single page for real
+uv run python -m tasks.archive_bot.main --page "نقاش المستخدم:Example"
+
+# Full run across all transcluding pages
+uv run python -m tasks.archive_bot.main
+```
+
+Options: `--dry-run`, `--page`, `--namespace`, `--limit`, `--sleep`.
+
+## Configuration
+
+Defaults live in `config/config_loader.py`; override via
+`config/settings.json` (same keys as `ArchiveBotConfig`). Notable values:
+
+- `template_name` / `template_title` — the `{{أرشفة آلية}}` template.
+- `namespace` — namespace to scan (3 = User talk).
+- `max_archive_size` — archive page byte size above which a new archive is
+  started (default `100000`).
+- `max_history` — max revisions to walk when locating the age snapshot.
+
+## Architecture
+
+```
+tasks/archive_bot/
+├── config/            # ArchiveBotConfig + settings.json loader
+├── domain/
+│   ├── entities/      # ArchiveConfig, Section, ArchiveResult
+│   ├── repositories/  # WikiRepository (abstract interface)
+│   └── use_cases/     # split_sections, parse_archive_config,
+│                      # decide_archive, archive_page
+├── data/              # PywikibotWikiRepository (pywikibot implementation)
+└── main.py            # entry point
+```
+
+Tests live in `tests/tasks/archive_bot/`:
+
+```bash
+uv run python -m unittest tests/tasks/archive_bot/test_*.py
+```

--- a/tasks/archive_bot/__init__.py
+++ b/tasks/archive_bot/__init__.py
@@ -1,0 +1,6 @@
+"""Archive bot task for LokasBot.
+
+Migrated from the legacy PHP archivebot (Peachy framework, archived at
+https://github.com/LokasWiki/archivebot). Archives old discussion threads
+from Arabic Wikipedia user talk pages that transclude ``{{أرشفة آلية}}``.
+"""

--- a/tasks/archive_bot/config/__init__.py
+++ b/tasks/archive_bot/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration for the archive_bot task."""

--- a/tasks/archive_bot/config/config_loader.py
+++ b/tasks/archive_bot/config/config_loader.py
@@ -1,0 +1,62 @@
+"""Configuration for the archive_bot task."""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, fields
+from typing import Optional
+
+
+@dataclass
+class ArchiveBotConfig:
+    """Configuration values for the archive_bot task."""
+
+    site_code: str = "ar"
+    site_family: str = "wikipedia"
+    #: Template name as it appears in wikitext.
+    template_name: str = "أرشفة آلية"
+    #: Template page title used for the transclusion lookup.
+    template_title: str = "قالب:أرشفة آلية"
+    #: Namespace to scan (3 = User talk).
+    namespace: int = 3
+    #: Minimum number of threads that must remain on the page.
+    min_threads_left: int = 0
+    #: Maximum number of threads to keep (0 = unlimited).
+    max_threads: int = 0
+    #: Maximum number of bytes to keep (0 = unlimited).
+    max_bytes: int = 0
+    #: Archive page byte size above which a new archive is started.
+    max_archive_size: int = 100000
+    #: Archive page byte size above which a new archive is started (total).
+    max_archive_total_size: int = 990000
+    #: Maximum number of revisions to walk when locating the old snapshot.
+    max_history: int = 5000
+    #: Seconds to sleep between processed pages.
+    sleep_between_pages: float = 3.0
+
+
+def load_config(path: Optional[str] = None) -> ArchiveBotConfig:
+    """Load configuration from a JSON file if present, else use defaults.
+
+    Args:
+        path: Path to a ``settings.json``; defaults to the file next to this
+            module.
+
+    Returns:
+        An :class:`ArchiveBotConfig` instance.
+    """
+    if path is None:
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "settings.json")
+
+    if os.path.exists(path):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+            valid = {field.name for field in fields(ArchiveBotConfig)}
+            filtered = {key: value for key, value in data.items() if key in valid}
+            return ArchiveBotConfig(**filtered)
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logging.warning("Failed to load %s: %s", path, exc)
+
+    return ArchiveBotConfig()

--- a/tasks/archive_bot/config/config_loader.py
+++ b/tasks/archive_bot/config/config_loader.py
@@ -33,6 +33,8 @@ class ArchiveBotConfig:
     max_history: int = 5000
     #: Seconds to sleep between processed pages.
     sleep_between_pages: float = 3.0
+    #: Mark the bot's edits as minor (تعديل طفيف).
+    minor_edit: bool = True
 
 
 def load_config(path: Optional[str] = None) -> ArchiveBotConfig:

--- a/tasks/archive_bot/data/__init__.py
+++ b/tasks/archive_bot/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data layer (infrastructure) for the archive_bot task."""

--- a/tasks/archive_bot/data/pywikibot_wiki_repository.py
+++ b/tasks/archive_bot/data/pywikibot_wiki_repository.py
@@ -1,0 +1,81 @@
+"""Pywikibot implementation of :class:`WikiRepository` for archive_bot."""
+
+import datetime
+import logging
+import re
+from typing import List, Optional
+
+import pywikibot
+
+from tasks.archive_bot.domain.repositories.wiki_repository import WikiRepository
+
+
+class PywikibotWikiRepository(WikiRepository):
+    """Wiki repository backed by pywikibot."""
+
+    def __init__(self, site: Optional[pywikibot.Site] = None,
+                 max_history: int = 5000):
+        self.site = site or pywikibot.Site()
+        self.max_history = max_history
+        self.logger = logging.getLogger(__name__)
+
+    def get_page_text(self, title: str) -> str:
+        page = pywikibot.Page(self.site, title)
+        if not page.exists():
+            return ""
+        return page.text
+
+    def page_exists(self, title: str) -> bool:
+        return pywikibot.Page(self.site, title).exists()
+
+    def save_page(self, title: str, text: str, summary: str) -> bool:
+        try:
+            page = pywikibot.Page(self.site, title)
+            page.text = text
+            page.save(summary=summary, minor=False)
+            return True
+        except Exception as exc:  # noqa: BLE001 - pywikibot raises many types
+            self.logger.error("Failed to save %s: %s", title, exc)
+            return False
+
+    def get_old_text(self, title: str,
+                     cutoff: datetime.datetime) -> Optional[str]:
+        page = pywikibot.Page(self.site, title)
+        try:
+            revisions = page.revisions(reverse=False, content=True,
+                                       total=self.max_history)
+            for revision in revisions:
+                timestamp = revision.get("timestamp")
+                if timestamp is not None and timestamp <= cutoff:
+                    return revision.get("text") or ""
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Failed to load history for %s: %s", title, exc)
+        return None
+
+    def is_sysop_protected(self, title: str) -> bool:
+        page = pywikibot.Page(self.site, title)
+        try:
+            protection = page.protection()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Failed to read protection for %s: %s", title, exc)
+            return False
+        edit = protection.get("edit")
+        return bool(edit and edit[0] == "sysop")
+
+    def list_archive_counters(self, base_prefix: str) -> List[int]:
+        page = pywikibot.Page(self.site, base_prefix)
+        namespace = page.namespace()
+        prefix = page.title(with_ns=False)
+        pattern = re.compile(re.escape(prefix) + r"\s*(\d+)\s*$")
+
+        counters: List[int] = []
+        for candidate in self.site.allpages(prefix=prefix, namespace=namespace):
+            match = pattern.match(candidate.title(with_ns=False))
+            if match:
+                counters.append(int(match.group(1)))
+        return counters
+
+    def get_transcluded_pages(self, template_title: str,
+                              namespace: int) -> List[str]:
+        page = pywikibot.Page(self.site, template_title)
+        return [p.title() for p in page.embeddedin(namespaces=namespace)]

--- a/tasks/archive_bot/data/pywikibot_wiki_repository.py
+++ b/tasks/archive_bot/data/pywikibot_wiki_repository.py
@@ -42,12 +42,20 @@ class PywikibotWikiRepository(WikiRepository):
                      cutoff: datetime.datetime) -> Optional[str]:
         page = pywikibot.Page(self.site, title)
         try:
-            revisions = page.revisions(reverse=False, content=True,
+            # Walk metadata-only (fast) to locate the newest revision at or
+            # before the cutoff, matching the legacy PHP history walk.
+            target_revid = None
+            revisions = page.revisions(reverse=False, content=False,
                                        total=self.max_history)
             for revision in revisions:
                 timestamp = revision.get("timestamp")
                 if timestamp is not None and timestamp <= cutoff:
-                    return revision.get("text") or ""
+                    target_revid = revision.get("revid")
+                    break
+            if target_revid is None:
+                return None
+            # Fetch only the single snapshot's content.
+            return page.getOldVersion(target_revid) or ""
         except Exception as exc:  # noqa: BLE001
             self.logger.error("Failed to load history for %s: %s", title, exc)
         return None

--- a/tasks/archive_bot/data/pywikibot_wiki_repository.py
+++ b/tasks/archive_bot/data/pywikibot_wiki_repository.py
@@ -14,9 +14,10 @@ class PywikibotWikiRepository(WikiRepository):
     """Wiki repository backed by pywikibot."""
 
     def __init__(self, site: Optional[pywikibot.Site] = None,
-                 max_history: int = 5000):
+                 max_history: int = 5000, minor_edit: bool = True):
         self.site = site or pywikibot.Site()
         self.max_history = max_history
+        self.minor_edit = minor_edit
         self.logger = logging.getLogger(__name__)
 
     def get_page_text(self, title: str) -> str:
@@ -32,7 +33,7 @@ class PywikibotWikiRepository(WikiRepository):
         try:
             page = pywikibot.Page(self.site, title)
             page.text = text
-            page.save(summary=summary, minor=False)
+            page.save(summary=summary, minor=self.minor_edit)
             return True
         except Exception as exc:  # noqa: BLE001 - pywikibot raises many types
             self.logger.error("Failed to save %s: %s", title, exc)

--- a/tasks/archive_bot/domain/__init__.py
+++ b/tasks/archive_bot/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain layer for the archive_bot task."""

--- a/tasks/archive_bot/domain/entities/__init__.py
+++ b/tasks/archive_bot/domain/entities/__init__.py
@@ -1,0 +1,7 @@
+"""Domain entities for the archive_bot task."""
+
+from tasks.archive_bot.domain.entities.archive_config import ArchiveConfig
+from tasks.archive_bot.domain.entities.archive_result import ArchiveResult
+from tasks.archive_bot.domain.entities.section import Section
+
+__all__ = ["ArchiveConfig", "ArchiveResult", "Section"]

--- a/tasks/archive_bot/domain/entities/archive_config.py
+++ b/tasks/archive_bot/domain/entities/archive_config.py
@@ -1,0 +1,49 @@
+"""Domain entity representing a parsed ``{{أرشفة آلية}}`` configuration."""
+
+from dataclasses import dataclass
+
+#: Archive by age (value = days).
+AGE_MODE = "قسم"
+#: Archive by size (value = kilobytes).
+SIZE_MODE = "حجم"
+
+
+@dataclass(frozen=True)
+class ArchiveConfig:
+    """Parsed configuration from a ``{{أرشفة آلية}}`` template.
+
+    The template is invoked on Arabic Wikipedia as::
+
+        {{أرشفة آلية|قسم|10|نقاش المستخدم:Example/أرشيف 6}}
+
+    Attributes:
+        archive_type: ``قسم`` (archive by age) or ``حجم`` (archive by size).
+        value: Days (age mode) or kilobytes (size mode).
+        base_prefix: Archive page prefix without the trailing counter,
+            e.g. ``نقاش المستخدم:Example/أرشيف``.
+        counter: Current archive counter (0 when not specified).
+    """
+
+    archive_type: str
+    value: int
+    base_prefix: str
+    counter: int = 0
+
+    @property
+    def is_age_mode(self) -> bool:
+        """Return True when archiving by age (``قسم``)."""
+        return self.archive_type == AGE_MODE
+
+    @property
+    def age_hours(self) -> int:
+        """Return the age threshold in hours.
+
+        Age mode uses ``value`` days; size mode archives threads that have
+        been unchanged for at least one hour.
+        """
+        return self.value * 24 if self.is_age_mode else 1
+
+    @property
+    def size_threshold_bytes(self) -> int:
+        """Return the page-size threshold in bytes (size mode only)."""
+        return self.value * 1000

--- a/tasks/archive_bot/domain/entities/archive_result.py
+++ b/tasks/archive_bot/domain/entities/archive_result.py
@@ -1,0 +1,30 @@
+"""Domain entity representing the outcome of archiving a single page."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ArchiveResult:
+    """Result of archiving one discussion page.
+
+    Attributes:
+        page_title: The talk page that was processed.
+        status: One of ``archived``, ``skipped``, ``failed`` or ``dry_run``.
+        reason: Human-readable reason for skipped/failed results.
+        archived_count: Number of sections moved to the archive.
+        kept_count: Number of sections left on the page.
+        archive_title: Title of the archive page that received the sections.
+        new_counter: The archive counter after the operation.
+        new_page_text: The page text that was (or would be) written.
+        new_archive_text: The archive text that was (or would be) written.
+    """
+
+    page_title: str
+    status: str = "skipped"
+    reason: str = ""
+    archived_count: int = 0
+    kept_count: int = 0
+    archive_title: str = ""
+    new_counter: int = 0
+    new_page_text: str = ""
+    new_archive_text: str = ""

--- a/tasks/archive_bot/domain/entities/section.py
+++ b/tasks/archive_bot/domain/entities/section.py
@@ -1,0 +1,34 @@
+"""Domain entity representing a wiki section."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Section:
+    """A discussion section (thread) on a talk page.
+
+    Attributes:
+        heading: The heading text without the surrounding ``=`` markers,
+            e.g. ``"عنوان"`` for ``== عنوان ==``.
+        content: The raw content that follows the heading line (it starts
+            with a newline) up to the next heading or the end of the text.
+        heading_markup: The original heading line (e.g. ``== عنوان ==``) used
+            for faithful reconstruction. When empty, the heading is rebuilt
+            as ``==heading==``.
+    """
+
+    heading: str
+    content: str
+    heading_markup: str = ""
+
+    def to_wikitext(self, level: int = 2) -> str:
+        """Return the section as wikitext (heading line + content)."""
+        if self.heading_markup:
+            return self.heading_markup + self.content
+        marker = "=" * level
+        return f"{marker}{self.heading}{marker}{self.content}"
+
+    @property
+    def size(self) -> int:
+        """Return the byte size of the section (MediaWiki page-size style)."""
+        return len(self.to_wikitext().encode("utf-8"))

--- a/tasks/archive_bot/domain/repositories/__init__.py
+++ b/tasks/archive_bot/domain/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Repository interfaces for the archive_bot task."""

--- a/tasks/archive_bot/domain/repositories/wiki_repository.py
+++ b/tasks/archive_bot/domain/repositories/wiki_repository.py
@@ -1,0 +1,44 @@
+"""Repository interface for wiki operations in the archive_bot task."""
+
+import datetime
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+
+class WikiRepository(ABC):
+    """Abstract interface for wiki operations needed by archive_bot.
+
+    Implementations back the domain use cases with concrete wiki access
+    (e.g. pywikibot), while in-memory fakes are used in tests.
+    """
+
+    @abstractmethod
+    def get_page_text(self, title: str) -> str:
+        """Return the current wikitext of ``title`` ('' when missing)."""
+
+    @abstractmethod
+    def page_exists(self, title: str) -> bool:
+        """Return True when ``title`` exists."""
+
+    @abstractmethod
+    def save_page(self, title: str, text: str, summary: str) -> bool:
+        """Save ``text`` to ``title`` and return True on success."""
+
+    @abstractmethod
+    def get_old_text(self, title: str, cutoff: datetime.datetime) -> Optional[str]:
+        """Return the text of the newest revision at or before ``cutoff``.
+
+        Returns ``None`` when no revision is old enough.
+        """
+
+    @abstractmethod
+    def is_sysop_protected(self, title: str) -> bool:
+        """Return True when ``title`` is sysop-protected from editing."""
+
+    @abstractmethod
+    def list_archive_counters(self, base_prefix: str) -> List[int]:
+        """Return the counters of existing archive pages under ``base_prefix``."""
+
+    @abstractmethod
+    def get_transcluded_pages(self, template_title: str, namespace: int) -> List[str]:
+        """Return titles of pages in ``namespace`` transcluding ``template_title``."""

--- a/tasks/archive_bot/domain/use_cases/__init__.py
+++ b/tasks/archive_bot/domain/use_cases/__init__.py
@@ -1,0 +1,1 @@
+"""Domain use cases for the archive_bot task."""

--- a/tasks/archive_bot/domain/use_cases/archive_page.py
+++ b/tasks/archive_bot/domain/use_cases/archive_page.py
@@ -1,0 +1,225 @@
+"""Use case orchestrating the archiving of a single discussion page.
+
+This ports the legacy PHP ``doarchive`` function (``script/Lib2.php``) into
+the project's clean-architecture style.
+"""
+
+import datetime
+import logging
+import re
+from typing import List, Tuple
+
+import wikitextparser as wtp
+
+from tasks.archive_bot.config.config_loader import ArchiveBotConfig
+from tasks.archive_bot.domain.entities.archive_config import ArchiveConfig
+from tasks.archive_bot.domain.entities.archive_result import ArchiveResult
+from tasks.archive_bot.domain.entities.section import Section
+from tasks.archive_bot.domain.repositories.wiki_repository import WikiRepository
+from tasks.archive_bot.domain.use_cases.decide_archive import classify
+from tasks.archive_bot.domain.use_cases.parse_archive_config import (
+    ParseArchiveConfig,
+)
+from tasks.archive_bot.domain.use_cases.split_sections import split_sections
+
+
+class ArchivePage:
+    """Orchestrate the archiving of one discussion page."""
+
+    def __init__(self, wiki_repository: WikiRepository,
+                 config: ArchiveBotConfig):
+        self.repository = wiki_repository
+        self.config = config
+        self.parser = ParseArchiveConfig(config.template_name)
+        self.logger = logging.getLogger(__name__)
+
+    def execute(self, page_title: str, dry_run: bool = False) -> ArchiveResult:
+        """Archive old threads from ``page_title``.
+
+        Args:
+            page_title: The talk page to process.
+            dry_run: When True, compute everything but do not save.
+
+        Returns:
+            An :class:`ArchiveResult` describing the outcome.
+        """
+        result = ArchiveResult(page_title=page_title)
+
+        text = self.repository.get_page_text(page_title)
+        if not text.strip():
+            result.reason = "empty or missing page"
+            return result
+
+        config = self.parser.parse(text)
+        if config is None:
+            result.reason = f"no {self.config.template_name} template"
+            return result
+
+        # Size mode: only archive once the page exceeds the threshold.
+        if not config.is_age_mode:
+            page_size = len(text.encode("utf-8"))
+            if page_size < config.size_threshold_bytes:
+                result.reason = (
+                    f"page size {page_size} below threshold "
+                    f"{config.size_threshold_bytes}"
+                )
+                return result
+
+        preamble, current_sections = self._split(text)
+        if not current_sections:
+            result.reason = "no level-2 sections"
+            return result
+
+        cutoff = (
+            datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            - datetime.timedelta(hours=config.age_hours)
+        )
+        old_text = self.repository.get_old_text(page_title, cutoff)
+        if old_text is None:
+            result.reason = "no revision older than the age threshold"
+            return result
+
+        _, old_sections = self._split(old_text)
+        keep, archive = classify(
+            current_sections,
+            old_sections,
+            min_threads_left=self.config.min_threads_left,
+            max_threads=self.config.max_threads,
+            max_bytes=self.config.max_bytes,
+        )
+        if not archive:
+            result.reason = "no sections to archive"
+            return result
+
+        counter, archive_title = self._resolve_archive_title(config)
+        existing_archive = self.repository.get_page_text(archive_title)
+        archive_text = self._assemble_archive_text(existing_archive, counter, archive)
+
+        # If the target archive is too large, roll over to a fresh one.
+        if existing_archive.strip() and (
+            len(existing_archive.encode("utf-8")) >= self.config.max_archive_size
+            or len(archive_text.encode("utf-8")) >= self.config.max_archive_total_size
+        ):
+            counter += 1
+            archive_title = f"{config.base_prefix} {counter}"
+            existing_archive = self.repository.get_page_text(archive_title)
+            archive_text = self._assemble_archive_text(existing_archive, counter,
+                                                       archive)
+
+        new_page_text = self._build_page_text(preamble, keep, counter)
+
+        result.archived_count = len(archive)
+        result.kept_count = len(keep)
+        result.archive_title = archive_title
+        result.new_counter = counter
+        result.new_page_text = new_page_text
+        result.new_archive_text = archive_text
+
+        if dry_run:
+            result.status = "dry_run"
+            return result
+
+        archive_summary = self._archive_summary(page_title, archive_title, len(archive))
+        page_summary = self._page_summary(page_title, archive_title, len(archive))
+
+        if not self.repository.save_page(archive_title, archive_text, archive_summary):
+            result.status = "failed"
+            result.reason = "failed to save archive page"
+            return result
+
+        if not self.repository.save_page(page_title, new_page_text, page_summary):
+            # Roll back the archive edit to keep the two pages consistent.
+            rollback_summary = (
+                f"الغاء أرشفة {self._count_label(len(archive))} من "
+                f"[[{archive_title}]]. (Archive failed)"
+            )
+            self.repository.save_page(archive_title, existing_archive,
+                                      rollback_summary)
+            result.status = "failed"
+            result.reason = "failed to save page; archive rolled back"
+            return result
+
+        result.status = "archived"
+        return result
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _split(text: str) -> Tuple[str, List[Section]]:
+        return split_sections(text, level=2)
+
+    def _resolve_archive_title(self, config: ArchiveConfig) -> Tuple[int, str]:
+        """Return ``(counter, archive_title)`` for the current archive."""
+        counters = self.repository.list_archive_counters(config.base_prefix)
+        max_existing = max(counters) if counters else 0
+        counter = config.counter if config.counter > 0 else (max_existing or 1)
+        return counter, f"{config.base_prefix} {counter}"
+
+    def _assemble_archive_text(self, existing: str, counter: int,
+                               sections: List[Section]) -> str:
+        body = "".join(section.to_wikitext() for section in sections)
+        if existing.strip():
+            return existing.rstrip() + "\n" + body
+        return self._archive_header(counter) + body
+
+    def _archive_header(self, counter: int) -> str:
+        return (
+            f"{{{{تصفح أرشيف|{counter}}}}}\n"
+            "{{تمت الأرشفة}}\n"
+            "{{أرشيف صفحة رئيسية}}\n"
+        )
+
+    def _build_page_text(self, preamble: str, keep: List[Section],
+                         counter: int) -> str:
+        body = "".join(section.to_wikitext() for section in keep)
+        return self._update_template_counter(preamble + body, counter)
+
+    def _update_template_counter(self, text: str, counter: int) -> str:
+        """Rewrite the trailing archive counter inside the config template."""
+        parsed = wtp.parse(text)
+        replacements = []
+        for template in parsed.templates:
+            if self._normalize(template.name) != self._normalize(
+                    self.config.template_name):
+                continue
+            new_raw = self._rewrite_counter(template.string, counter)
+            replacements.append((template.span[0], template.span[1], new_raw))
+
+        for start, end, new_raw in reversed(replacements):
+            text = text[:start] + new_raw + text[end:]
+        return text
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        return name.strip().replace("_", " ").lower()
+
+    @staticmethod
+    def _rewrite_counter(raw_template: str, counter: int) -> str:
+        """Replace the trailing counter inside a raw template string."""
+        match = re.search(r"(\d+)\s*\}\}\s*$", raw_template)
+        if match:
+            return (raw_template[: match.start(1)] + str(counter)
+                    + raw_template[match.end(1):])
+        # No counter present: insert one before the closing braces.
+        return re.sub(r"(\s*)(\}\}\s*)$",
+                      lambda found: f" {counter}{found.group(2)}", raw_template)
+
+    @staticmethod
+    def _count_label(count: int) -> str:
+        """Return the Arabic plural label used in edit summaries."""
+        if count == 1:
+            return "نقاش واحد"
+        if count == 2:
+            return "نقاشان"
+        if 2 < count <= 10:
+            return f"{count} نقاشات"
+        return f"{count} نقاش"
+
+    def _archive_summary(self, page_title: str, archive_title: str,
+                         count: int) -> str:
+        return f"أرشفة {self._count_label(count)} من [[{page_title}]]"
+
+    def _page_summary(self, page_title: str, archive_title: str,
+                      count: int) -> str:
+        return f"أرشفة {self._count_label(count)} إلى [[{archive_title}]]"

--- a/tasks/archive_bot/domain/use_cases/decide_archive.py
+++ b/tasks/archive_bot/domain/use_cases/decide_archive.py
@@ -1,0 +1,109 @@
+"""Classify discussion sections into keep vs archive.
+
+Ports the keep/archive decision logic of the legacy PHP ``doarchive``
+function (``script/Lib2.php``).
+"""
+
+import re
+from typing import Dict, List, Tuple
+
+from tasks.archive_bot.domain.entities.section import Section
+
+#: Template that marks a section as not archivable (``{{لا للأرشفة}}``).
+DO_NOT_ARCHIVE_RE = re.compile(r"\{\{\s*لا للأرشفة\s*\}\}")
+
+
+def _keyed_sections(sections: List[Section]) -> List[Tuple[str, Section]]:
+    """Assign a unique key to each section, like the PHP splitter.
+
+    Duplicate headings are disambiguated with a numeric suffix (``X``,
+    ``X 2``, ``X 3``, ...) so that the same heading in the old and current
+    snapshots maps to the same key.
+    """
+    keyed: List[Tuple[str, Section]] = []
+    seen: Dict[str, int] = {}
+    for section in sections:
+        base = section.heading.strip()
+        count = seen.get(base, 0) + 1
+        seen[base] = count
+        key = base if count == 1 else f"{base} {count}"
+        keyed.append((key, section))
+    return keyed
+
+
+def classify(
+    current_sections: List[Section],
+    old_sections: List[Section],
+    min_threads_left: int = 0,
+    max_threads: int = 0,
+    max_bytes: int = 0,
+) -> Tuple[List[Section], List[Section]]:
+    """Split ``current_sections`` into ``(keep, archive)`` lists.
+
+    A section is archived when its content is unchanged compared with the
+    ``old_sections`` snapshot (i.e. it has had no activity for the age
+    threshold). Sections marked with ``{{لا للأرشفة}}`` or that are new
+    are always kept.
+
+    Args:
+        current_sections: Sections of the current page text.
+        old_sections: Sections of the age-threshold snapshot.
+        min_threads_left: Minimum number of threads that must remain.
+        max_threads: Maximum number of threads to keep (0 = unlimited).
+        max_bytes: Maximum number of bytes to keep (0 = unlimited).
+
+    Returns:
+        A tuple ``(keep, archive)`` preserving document order.
+    """
+    old_index: Dict[str, Section] = dict(_keyed_sections(old_sections))
+    keep: List[Section] = []
+    archive: List[Section] = []
+
+    for key, section in _keyed_sections(current_sections):
+        remaining = len(current_sections) - len(archive)
+        if remaining <= min_threads_left:
+            keep.append(section)
+        elif DO_NOT_ARCHIVE_RE.search(section.content):
+            keep.append(section)
+        elif key not in old_index:
+            keep.append(section)
+        elif section.content.strip() == old_index[key].content.strip():
+            archive.append(section)
+        else:
+            keep.append(section)
+
+    if max_threads > 0 or max_bytes > 0:
+        keep, archive = _enforce_limits(keep, archive, max_threads, max_bytes)
+
+    return keep, archive
+
+
+def _enforce_limits(
+    keep: List[Section],
+    archive: List[Section],
+    max_threads: int,
+    max_bytes: int,
+) -> Tuple[List[Section], List[Section]]:
+    """Move the oldest excess kept sections to the archive.
+
+    Iterates from newest to oldest so the newest threads remain on the page.
+    """
+    count = 0
+    total_bytes = 0
+    new_keep: List[Section] = []
+    overflow: List[Section] = []
+
+    for section in reversed(keep):
+        count += 1
+        total_bytes += len(section.content.encode("utf-8"))
+        if (max_threads > 0 and count > max_threads) or (
+            max_bytes > 0 and total_bytes > max_bytes
+        ):
+            overflow.append(section)
+        else:
+            new_keep.append(section)
+
+    # Restore document order.
+    new_keep.reverse()
+    overflow.reverse()
+    return new_keep, archive + overflow

--- a/tasks/archive_bot/domain/use_cases/parse_archive_config.py
+++ b/tasks/archive_bot/domain/use_cases/parse_archive_config.py
@@ -1,0 +1,87 @@
+"""Parse the ``{{أرشفة آلية}}`` configuration template.
+
+Uses :mod:`wikitextparser` (the project's standard wikitext parsing library)
+instead of the fragile ``explode``/regex parsing used by the legacy PHP bot.
+"""
+
+import re
+from typing import Optional, Tuple
+
+import wikitextparser as wtp
+
+from tasks.archive_bot.domain.entities.archive_config import ArchiveConfig
+
+#: Template name as it appears in wikitext.
+TEMPLATE_NAME = "أرشفة آلية"
+
+#: Legacy flag sometimes inserted between the value and the prefix.
+LEGACY_FLAGS = {"عددي", "عددى"}
+
+#: Matches the trailing archive counter inside the prefix argument.
+_COUNTER_RE = re.compile(r"(\d+)\s*$")
+
+
+def _normalize(name: str) -> str:
+    """Normalize a template name for comparison."""
+    return name.strip().replace("_", " ").lower()
+
+
+class ParseArchiveConfig:
+    """Parse an :class:`ArchiveConfig` from page wikitext."""
+
+    def __init__(self, template_name: str = TEMPLATE_NAME):
+        self.template_name = _normalize(template_name)
+
+    def parse(self, text: str) -> Optional[ArchiveConfig]:
+        """Return the first archive config found in ``text`` or ``None``."""
+        if not text:
+            return None
+
+        for template in wtp.parse(text).templates:
+            if _normalize(template.name) != self.template_name:
+                continue
+            config = self._parse_template(template)
+            if config is not None:
+                return config
+        return None
+
+    def _parse_template(self, template) -> Optional[ArchiveConfig]:
+        """Parse a single ``{{أرشفة آلية}}`` template object."""
+        # Collect positional arguments, dropping the legacy 'عددي'/'عددى' flag.
+        values = []
+        for argument in template.arguments:
+            if not argument.positional:
+                continue
+            value = argument.value.strip()
+            if value in LEGACY_FLAGS:
+                continue
+            values.append(value)
+
+        if len(values) < 3:
+            return None
+
+        archive_type = values[0]
+        try:
+            value = int(values[1])
+        except ValueError:
+            return None
+
+        base_prefix, counter = self._split_counter(values[2])
+        return ArchiveConfig(
+            archive_type=archive_type,
+            value=value,
+            base_prefix=base_prefix,
+            counter=counter,
+        )
+
+    @staticmethod
+    def _split_counter(raw_prefix: str) -> Tuple[str, int]:
+        """Split the prefix argument into ``(base_prefix, counter)``.
+
+        The prefix carries the current archive counter as trailing digits,
+        e.g. ``نقاش المستخدم:Example/أرشيف 6`` → counter ``6``.
+        """
+        match = _COUNTER_RE.search(raw_prefix)
+        if match:
+            return raw_prefix[: match.start()].rstrip(), int(match.group(1))
+        return raw_prefix.rstrip(), 0

--- a/tasks/archive_bot/domain/use_cases/split_sections.py
+++ b/tasks/archive_bot/domain/use_cases/split_sections.py
@@ -1,0 +1,60 @@
+"""Split wikitext into a preamble and level-N sections.
+
+This is a faithful but cleaner port of the legacy PHP ``splitintosections``
+helper (``script/Lib2.php`` of the archived PHP bot).
+"""
+
+import re
+from typing import List, Tuple
+
+from tasks.archive_bot.domain.entities.section import Section
+
+
+def split_sections(text: str, level: int = 2) -> Tuple[str, List[Section]]:
+    """Split ``text`` into a preamble and a list of level-``level`` sections.
+
+    A heading line must start with exactly ``level`` ``=`` characters (not
+    followed by another ``=``) and end with exactly ``level`` ``=`` characters
+    (not preceded by another ``=``), e.g. ``== عنوان ==`` for ``level == 2``.
+    Everything before the first heading is returned as the preamble; each
+    heading plus its trailing content (up to the next heading or EOF) becomes
+    a :class:`Section`.
+
+    Args:
+        text: The wikitext to split.
+        level: The heading level to split on (default 2).
+
+    Returns:
+        A tuple ``(preamble, sections)``.
+    """
+    if not text:
+        return "", []
+
+    marker = "=" * level
+    # A heading occupies a full line: exactly `level` '=' at the start (not
+    # followed by '='), any text, then exactly `level` '=' at the end (not
+    # preceded by '='), optionally followed by trailing spaces/tabs.
+    pattern = re.compile(
+        rf"^{re.escape(marker)}(?!=)(?P<head>.*?)(?<!=){re.escape(marker)}"
+        r"[ \t]*(?=\n|$)",
+        re.MULTILINE,
+    )
+
+    matches = list(pattern.finditer(text))
+    if not matches:
+        return text, []
+
+    preamble = text[: matches[0].start()]
+    sections: List[Section] = []
+
+    for index, match in enumerate(matches):
+        heading = match.group("head").strip()
+        heading_markup = match.group(0).rstrip()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections.append(
+            Section(heading=heading, content=text[start:end],
+                    heading_markup=heading_markup)
+        )
+
+    return preamble, sections

--- a/tasks/archive_bot/main.py
+++ b/tasks/archive_bot/main.py
@@ -73,7 +73,8 @@ def main() -> None:
 
     config = load_config()
     site = pywikibot.Site(config.site_code, config.site_family)
-    repository = PywikibotWikiRepository(site, max_history=config.max_history)
+    repository = PywikibotWikiRepository(site, max_history=config.max_history,
+                                      minor_edit=config.minor_edit)
     use_case = ArchivePage(repository, config)
 
     sleep = args.sleep if args.sleep is not None else config.sleep_between_pages

--- a/tasks/archive_bot/main.py
+++ b/tasks/archive_bot/main.py
@@ -1,0 +1,105 @@
+"""
+Main entry point for the archive_bot task.
+
+Scans Arabic Wikipedia user talk pages (namespace 3) that transclude
+``{{أرشفة آلية}}`` and archives their old discussion threads.
+
+Usage::
+
+    uv run python -m tasks.archive_bot.main --dry-run
+    uv run python -m tasks.archive_bot.main --page "نقاش المستخدم:Example"
+"""
+
+import argparse
+import logging
+import time
+from typing import List
+
+import pywikibot
+
+from tasks.archive_bot.config.config_loader import ArchiveBotConfig, load_config
+from tasks.archive_bot.data.pywikibot_wiki_repository import PywikibotWikiRepository
+from tasks.archive_bot.domain.use_cases.archive_page import ArchivePage
+
+
+def setup_logging() -> None:
+    """Configure logging to a file and the console."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.FileHandler("archive_bot.log"),
+            logging.StreamHandler(),
+        ],
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Archive old threads from {{أرشفة آلية}} talk pages."
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute without saving anything.")
+    parser.add_argument("--page", help="Archive a single page title.")
+    parser.add_argument("--namespace", type=int, default=None,
+                        help="Override the namespace to scan.")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit the number of pages to process.")
+    parser.add_argument("--sleep", type=float, default=None,
+                        help="Override seconds to sleep between pages.")
+    return parser
+
+
+def collect_titles(args: argparse.Namespace, config: ArchiveBotConfig,
+                   repository: PywikibotWikiRepository) -> List[str]:
+    """Return the list of page titles to process."""
+    namespace = args.namespace if args.namespace is not None else config.namespace
+
+    if args.page:
+        return [args.page]
+
+    titles = repository.get_transcluded_pages(config.template_title, namespace)
+    if args.limit is not None:
+        titles = titles[: args.limit]
+    return titles
+
+
+def main() -> None:
+    """Run the archive_bot task."""
+    args = build_parser().parse_args()
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
+    config = load_config()
+    site = pywikibot.Site(config.site_code, config.site_family)
+    repository = PywikibotWikiRepository(site, max_history=config.max_history)
+    use_case = ArchivePage(repository, config)
+
+    sleep = args.sleep if args.sleep is not None else config.sleep_between_pages
+    titles = collect_titles(args, config, repository)
+
+    summary = {"archived": 0, "dry_run": 0, "skipped": 0, "failed": 0}
+
+    for index, title in enumerate(titles):
+        if args.page is None and "/" in title:
+            logger.info("Skip subpage: %s", title)
+            continue
+        if repository.is_sysop_protected(title):
+            logger.info("Skip sysop-protected page: %s", title)
+            continue
+
+        logger.info("Processing %s ...", title)
+        result = use_case.execute(title, dry_run=args.dry_run)
+        summary[result.status] = summary.get(result.status, 0) + 1
+        logger.info("  -> %s (%s)", result.status,
+                    result.reason or f"{result.archived_count} sections archived")
+
+        if not args.dry_run and sleep > 0 and index < len(titles) - 1:
+            time.sleep(sleep)
+
+    logger.info("Finished: %s", summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/archive_bot/__init__.py
+++ b/tests/tasks/archive_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the archive_bot task."""

--- a/tests/tasks/archive_bot/test_archive_config_entity.py
+++ b/tests/tasks/archive_bot/test_archive_config_entity.py
@@ -1,0 +1,31 @@
+"""Tests for the ArchiveConfig entity."""
+
+import unittest
+
+from tasks.archive_bot.domain.entities.archive_config import (
+    AGE_MODE,
+    SIZE_MODE,
+    ArchiveConfig,
+)
+
+
+class TestArchiveConfig(unittest.TestCase):
+    """Tests for :class:`ArchiveConfig`."""
+
+    def test_age_mode_hours(self):
+        config = ArchiveConfig(archive_type=AGE_MODE, value=10,
+                               base_prefix="نقاش المستخدم:X/أرشيف", counter=1)
+        self.assertTrue(config.is_age_mode)
+        self.assertEqual(config.age_hours, 240)
+        self.assertEqual(config.size_threshold_bytes, 10000)
+
+    def test_size_mode_hours(self):
+        config = ArchiveConfig(archive_type=SIZE_MODE, value=70,
+                               base_prefix="نقاش المستخدم:X/أرشيف", counter=1)
+        self.assertFalse(config.is_age_mode)
+        self.assertEqual(config.age_hours, 1)
+        self.assertEqual(config.size_threshold_bytes, 70000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/archive_bot/test_archive_page.py
+++ b/tests/tasks/archive_bot/test_archive_page.py
@@ -1,0 +1,167 @@
+"""Tests for the ArchivePage orchestration use case."""
+
+import datetime
+import unittest
+
+from tasks.archive_bot.config.config_loader import ArchiveBotConfig
+from tasks.archive_bot.domain.repositories.wiki_repository import WikiRepository
+from tasks.archive_bot.domain.use_cases.archive_page import ArchivePage
+
+
+class FakeRepository(WikiRepository):
+    """In-memory repository for testing the archive use case."""
+
+    def __init__(self):
+        self.pages = {}          # title -> text
+        self.revisions = {}      # title -> list[(timestamp, text)] newest first
+        self.protected = set()   # sysop-protected titles
+        self.fail_saves = set()  # titles whose save() fails
+        self.saves = []          # (title, text, summary)
+
+    def get_page_text(self, title):
+        return self.pages.get(title, "")
+
+    def page_exists(self, title):
+        return title in self.pages
+
+    def save_page(self, title, text, summary):
+        if title in self.fail_saves:
+            return False
+        self.saves.append((title, text, summary))
+        self.pages[title] = text
+        return True
+
+    def get_old_text(self, title, cutoff):
+        for timestamp, text in self.revisions.get(title, []):
+            if timestamp <= cutoff:
+                return text
+        return None
+
+    def is_sysop_protected(self, title):
+        return title in self.protected
+
+    def list_archive_counters(self, base_prefix):
+        counters = []
+        for title in self.pages:
+            if title.startswith(base_prefix + " "):
+                suffix = title[len(base_prefix):].strip()
+                if suffix.isdigit():
+                    counters.append(int(suffix))
+        return counters
+
+    def get_transcluded_pages(self, template_title, namespace):
+        return list(self.pages)
+
+
+def make_config(**overrides):
+    defaults = {
+        "site_code": "ar",
+        "site_family": "wikipedia",
+        "template_name": "أرشفة آلية",
+        "template_title": "قالب:أرشفة آلية",
+        "namespace": 3,
+    }
+    defaults.update(overrides)
+    return ArchiveBotConfig(**defaults)
+
+
+class TestArchivePage(unittest.TestCase):
+    """Tests for :class:`ArchivePage`."""
+
+    def _age_mode_setup(self):
+        repo = FakeRepository()
+        page = "نقاش المستخدم:X"
+        tpl = "{{أرشفة آلية|قسم|10|نقاش المستخدم:X/أرشيف 1}}"
+        old_text = tpl + "\n\n== قديم ==\nنقاش قديم\n"
+        new_text = tpl + "\n\n== قديم ==\nنقاش قديم\n\n== جديد ==\nنقاش جديد\n"
+        repo.pages[page] = new_text
+        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        repo.revisions[page] = [
+            (now - datetime.timedelta(hours=1), new_text),
+            (now - datetime.timedelta(days=20), old_text),
+        ]
+        use_case = ArchivePage(repo, make_config())
+        return repo, use_case, page
+
+    def test_age_mode_archives_unchanged_section(self):
+        repo, use_case, page = self._age_mode_setup()
+        result = use_case.execute(page)
+
+        self.assertEqual(result.status, "archived")
+        self.assertEqual(result.archived_count, 1)
+        self.assertEqual(result.kept_count, 1)
+        self.assertEqual(result.archive_title, "نقاش المستخدم:X/أرشيف 1")
+
+        archive_text = repo.pages["نقاش المستخدم:X/أرشيف 1"]
+        self.assertIn("{{تصفح أرشيف|1}}", archive_text)
+        self.assertIn("== قديم ==", archive_text)
+        self.assertNotIn("== جديد ==", archive_text)
+
+        page_text = repo.pages[page]
+        self.assertIn("== جديد ==", page_text)
+        self.assertNotIn("== قديم ==", page_text)
+
+    def test_size_mode_below_threshold_skipped(self):
+        repo = FakeRepository()
+        page = "نقاش المستخدم:X"
+        repo.pages[page] = (
+            "{{أرشفة آلية|حجم|100|نقاش المستخدم:X/أرشيف 1}}\n"
+            "== قديم ==\nنقاش\n"
+        )
+        use_case = ArchivePage(repo, make_config())
+        result = use_case.execute(page)
+        self.assertEqual(result.status, "skipped")
+        self.assertIn("below threshold", result.reason)
+        self.assertEqual(repo.saves, [])
+
+    def test_dry_run_does_not_save(self):
+        repo, use_case, page = self._age_mode_setup()
+        result = use_case.execute(page, dry_run=True)
+
+        self.assertEqual(result.status, "dry_run")
+        self.assertEqual(result.archived_count, 1)
+        self.assertEqual(repo.saves, [])
+        # Page and archive remain untouched.
+        self.assertNotIn("نقاش المستخدم:X/أرشيف 1", repo.pages)
+
+    def test_no_template_skipped(self):
+        repo = FakeRepository()
+        page = "نقاش المستخدم:X"
+        repo.pages[page] = "== قسم ==\nنقاش بلا قالب\n"
+        use_case = ArchivePage(repo, make_config())
+        result = use_case.execute(page)
+        self.assertEqual(result.status, "skipped")
+        self.assertIn("no", result.reason)
+
+    def test_rollback_on_page_save_failure(self):
+        repo, use_case, page = self._age_mode_setup()
+        repo.fail_saves.add(page)
+
+        result = use_case.execute(page)
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("rolled back", result.reason)
+        # Archive was first written, then rolled back to empty.
+        archive_title = "نقاش المستخدم:X/أرشيف 1"
+        self.assertEqual(repo.pages[archive_title], "")
+
+    def test_rollover_to_new_counter_when_archive_full(self):
+        repo, use_case, page = self._age_mode_setup()
+        # Make the target archive too large to force a new counter.
+        repo.pages["نقاش المستخدم:X/أرشيف 1"] = "X" * 50
+        use_case.config.max_archive_size = 10
+        use_case.config.max_archive_total_size = 20
+
+        result = use_case.execute(page)
+
+        self.assertEqual(result.status, "archived")
+        self.assertEqual(result.archive_title, "نقاش المستخدم:X/أرشيف 2")
+        self.assertEqual(result.new_counter, 2)
+        self.assertIn("{{تصفح أرشيف|2}}",
+                      repo.pages["نقاش المستخدم:X/أرشيف 2"])
+        # The page template counter was updated to 2.
+        self.assertIn("نقاش المستخدم:X/أرشيف 2", repo.pages[page])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/archive_bot/test_decide_archive.py
+++ b/tests/tasks/archive_bot/test_decide_archive.py
@@ -1,0 +1,95 @@
+"""Tests for the keep-vs-archive decision engine."""
+
+import unittest
+
+from tasks.archive_bot.domain.entities.section import Section
+from tasks.archive_bot.domain.use_cases.decide_archive import classify
+
+
+def section(heading, content):
+    return Section(heading=heading, content=content,
+                   heading_markup=f"== {heading} ==")
+
+
+class TestClassify(unittest.TestCase):
+    """Tests for :func:`classify`."""
+
+    def test_unchanged_section_archived(self):
+        current = [section("قديم", "\nنقاش قديم\n")]
+        old = [section("قديم", "\nنقاش قديم\n")]
+        keep, archive = classify(current, old)
+        self.assertEqual(archive, current)
+        self.assertEqual(keep, [])
+
+    def test_new_section_kept(self):
+        current = [section("قديم", "\nنقاش\n"), section("جديد", "\nنقاش جديد\n")]
+        old = [section("قديم", "\nنقاش\n")]
+        keep, archive = classify(current, old)
+        self.assertEqual(keep, [current[1]])
+        self.assertEqual(archive, [current[0]])
+
+    def test_changed_section_kept(self):
+        current = [section("قديم", "\nنقاش معدل\n")]
+        old = [section("قديم", "\nنقاش\n")]
+        keep, archive = classify(current, old)
+        self.assertEqual(keep, current)
+        self.assertEqual(archive, [])
+
+    def test_do_not_archive_kept(self):
+        current = [section("قديم", "\nنقاش {{لا للأرشفة}}\n")]
+        old = [section("قديم", "\nنقاش {{لا للأرشفة}}\n")]
+        keep, archive = classify(current, old)
+        self.assertEqual(keep, current)
+        self.assertEqual(archive, [])
+
+    def test_do_not_archive_with_whitespace(self):
+        current = [section("قديم", "\nنقاش {{ لا للأرشفة }}\n")]
+        old = [section("قديم", "\nنقاش {{ لا للأرشفة }}\n")]
+        keep, archive = classify(current, old)
+        self.assertEqual(keep, current)
+        self.assertEqual(archive, [])
+
+    def test_duplicate_headings_match_positionally(self):
+        current = [
+            section("أ", "\n1"),
+            section("أ", "\n2"),
+            section("أ", "\n3"),
+        ]
+        old = [
+            section("أ", "\n1"),
+            section("أ", "\n2"),
+        ]
+        keep, archive = classify(current, old)
+        # Third "أ" is new -> kept; first two unchanged -> archived.
+        self.assertEqual(archive, current[:2])
+        self.assertEqual(keep, current[2:])
+
+    def test_min_threads_left(self):
+        current = [
+            section("أ", "\n1"),
+            section("ب", "\n2"),
+            section("ج", "\n3"),
+        ]
+        old = current[:]  # all unchanged
+        keep, archive = classify(current, old, min_threads_left=2)
+        # At least 2 threads must remain.
+        self.assertEqual(len(keep), 2)
+        self.assertEqual(len(archive), 1)
+
+    def test_max_threads_overflow_archived(self):
+        current = [
+            section("أ", "\n1"),
+            section("ب", "\n2"),
+            section("ج", "\n3"),
+        ]
+        old = []  # all new -> all kept initially
+        keep, archive = classify(current, old, max_threads=2)
+        self.assertEqual(len(keep), 2)
+        self.assertEqual(len(archive), 1)
+        # Newest threads remain: "ب" and "ج" kept, oldest "أ" archived.
+        self.assertEqual(keep, current[1:])
+        self.assertEqual(archive, current[:1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/archive_bot/test_parse_archive_config.py
+++ b/tests/tasks/archive_bot/test_parse_archive_config.py
@@ -1,0 +1,99 @@
+"""Tests for the {{أرشفة آلية}} template parser."""
+
+import unittest
+
+from tasks.archive_bot.domain.entities.archive_config import AGE_MODE, SIZE_MODE
+from tasks.archive_bot.domain.use_cases.parse_archive_config import (
+    ParseArchiveConfig,
+)
+
+
+class TestParseArchiveConfig(unittest.TestCase):
+    """Tests for :class:`ParseArchiveConfig`."""
+
+    def setUp(self):
+        self.parser = ParseArchiveConfig()
+
+    def test_age_mode(self):
+        config = self.parser.parse(
+            "{{أرشفة آلية|قسم|10|نقاش المستخدم:مبتدئ/أرشيف 6}}"
+        )
+        self.assertIsNotNone(config)
+        self.assertEqual(config.archive_type, AGE_MODE)
+        self.assertEqual(config.value, 10)
+        self.assertEqual(config.base_prefix, "نقاش المستخدم:مبتدئ/أرشيف")
+        self.assertEqual(config.counter, 6)
+        self.assertTrue(config.is_age_mode)
+        self.assertEqual(config.age_hours, 240)
+
+    def test_size_mode(self):
+        config = self.parser.parse(
+            "{{أرشفة آلية|حجم|70|نقاش المستخدم:Elsayed Taha/أرشيف 2}}"
+        )
+        self.assertIsNotNone(config)
+        self.assertEqual(config.archive_type, SIZE_MODE)
+        self.assertEqual(config.value, 70)
+        self.assertEqual(config.counter, 2)
+        self.assertFalse(config.is_age_mode)
+        self.assertEqual(config.age_hours, 1)
+        self.assertEqual(config.size_threshold_bytes, 70000)
+
+    def test_legacy_flag_عددي(self):
+        config = self.parser.parse(
+            "{{أرشفة آلية|قسم|7|عددي|نقاش المستخدم:Nassim-alge/أرشيف 1}}"
+        )
+        self.assertIsNotNone(config)
+        self.assertEqual(config.archive_type, AGE_MODE)
+        self.assertEqual(config.value, 7)
+        self.assertEqual(config.base_prefix, "نقاش المستخدم:Nassim-alge/أرشيف")
+        self.assertEqual(config.counter, 1)
+
+    def test_legacy_flag_عددى(self):
+        config = self.parser.parse(
+            "{{أرشفة آلية|قسم|7|عددى|نقاش المستخدم:Reiser115/أرشيف 1}}"
+        )
+        self.assertIsNotNone(config)
+        self.assertEqual(config.counter, 1)
+
+    def test_no_counter(self):
+        config = self.parser.parse(
+            "{{أرشفة آلية|حجم|100|نقاش المستخدم:مواطن تونسي/أرشيف }}"
+        )
+        self.assertIsNotNone(config)
+        self.assertEqual(config.base_prefix, "نقاش المستخدم:مواطن تونسي/أرشيف")
+        self.assertEqual(config.counter, 0)
+
+    def test_embedded_in_page_text(self):
+        text = (
+            "مقدمة\n"
+            "{{أرشفة آلية|قسم|15|نقاش المستخدم:Example/أرشيف 3}}\n"
+            "== قسم ==\nنقاش\n"
+        )
+        config = self.parser.parse(text)
+        self.assertIsNotNone(config)
+        self.assertEqual(config.counter, 3)
+
+    def test_whitespace_tolerance(self):
+        config = self.parser.parse(
+            "{{ أرشفة آلية | قسم | 10 | نقاش المستخدم:Example/أرشيف 6 }}"
+        )
+        self.assertIsNotNone(config)
+        self.assertEqual(config.archive_type, AGE_MODE)
+        self.assertEqual(config.value, 10)
+        self.assertEqual(config.base_prefix, "نقاش المستخدم:Example/أرشيف")
+        self.assertEqual(config.counter, 6)
+
+    def test_no_template_returns_none(self):
+        self.assertIsNone(self.parser.parse("== قسم ==\nنقاش بلا قالب"))
+
+    def test_missing_params_returns_none(self):
+        self.assertIsNone(self.parser.parse("{{أرشفة آلية|قسم|10}}"))
+
+    def test_non_integer_value_returns_none(self):
+        self.assertIsNone(
+            self.parser.parse("{{أرشفة آلية|قسم|عشرة|نقاش المستخدم:X/أرشيف 1}}")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/archive_bot/test_split_sections.py
+++ b/tests/tasks/archive_bot/test_split_sections.py
@@ -1,0 +1,84 @@
+"""Tests for the section splitter."""
+
+import unittest
+
+from tasks.archive_bot.domain.use_cases.split_sections import split_sections
+
+
+class TestSplitSections(unittest.TestCase):
+    """Tests for :func:`split_sections`."""
+
+    def test_split_with_preamble(self):
+        text = "Intro\n== Section A ==\nContent A\n== Section B ==\nContent B"
+        preamble, sections = split_sections(text)
+        self.assertEqual(preamble, "Intro\n")
+        self.assertEqual(len(sections), 2)
+        self.assertEqual(sections[0].heading, "Section A")
+        self.assertEqual(sections[0].content, "\nContent A\n")
+        self.assertEqual(sections[1].heading, "Section B")
+        self.assertEqual(sections[1].content, "\nContent B")
+
+    def test_no_preamble(self):
+        text = "== فقط ==\nBody"
+        preamble, sections = split_sections(text)
+        self.assertEqual(preamble, "")
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0].heading, "فقط")
+        self.assertEqual(sections[0].content, "\nBody")
+
+    def test_level_three_headings_ignored(self):
+        text = "=== مستوى ثالث ===\nskip me"
+        preamble, sections = split_sections(text)
+        self.assertEqual(preamble, text)
+        self.assertEqual(sections, [])
+
+    def test_no_headings(self):
+        text = "Text without headings"
+        preamble, sections = split_sections(text)
+        self.assertEqual(preamble, text)
+        self.assertEqual(sections, [])
+
+    def test_empty_text(self):
+        self.assertEqual(split_sections(""), ("", []))
+
+    def test_nested_level_three_is_content(self):
+        text = "== a ==\n1\n=== sub ===\nsubbody\n== b ==\n2"
+        preamble, sections = split_sections(text)
+        self.assertEqual(preamble, "")
+        self.assertEqual(len(sections), 2)
+        self.assertEqual(sections[0].content, "\n1\n=== sub ===\nsubbody\n")
+
+    def test_heading_without_spaces(self):
+        text = "==أرشفة==\nno spaces"
+        _, sections = split_sections(text)
+        self.assertEqual(sections[0].heading, "أرشفة")
+        self.assertEqual(sections[0].heading_markup, "==أرشفة==")
+
+    def test_duplicate_headings(self):
+        text = "== a ==\n1\n== a ==\n2\n== a ==\n3\n"
+        _, sections = split_sections(text)
+        self.assertEqual([s.heading for s in sections], ["a", "a", "a"])
+        self.assertEqual(len(sections), 3)
+
+    def test_trailing_text_not_a_heading(self):
+        text = "Preamble\n== a == trailing\ncontent\n"
+        preamble, sections = split_sections(text)
+        self.assertEqual(preamble, text)
+        self.assertEqual(sections, [])
+
+    def test_roundtrip_preserves_text(self):
+        text = "Intro\n== A ==\nBody A\n== B ==\nBody B"
+        preamble, sections = split_sections(text)
+        rebuilt = preamble + "".join(s.to_wikitext() for s in sections)
+        self.assertEqual(rebuilt, text)
+
+    def test_heading_markup_preserved(self):
+        text = "==  عنوان  ==\nBody"
+        _, sections = split_sections(text)
+        self.assertEqual(sections[0].heading, "عنوان")
+        self.assertEqual(sections[0].heading_markup, "==  عنوان  ==")
+        self.assertEqual(sections[0].to_wikitext(), text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toolforge/cronjobs.yaml
+++ b/toolforge/cronjobs.yaml
@@ -2,88 +2,88 @@
   name: dummy-defaults-job
   command: echo this is a dummy job to set defaults
   emails: onfailure
-  image: tf-python39
+  image: python3.13
   no-filelog: false
 - name: test-pull
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/ci_cd_log_task.sh
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: statistics-daily
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/statistics-daily.sh
   schedule: '0 1 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: statistics-weekly
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/statistics-weekly.sh
   schedule: '0 2 * * 1'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
 - name: utw-daily
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/users_this_week-daily.sh
   schedule: '0 2 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: utw-weekly
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/users_this_week-weekly.sh
   schedule: '0 2 * * 1'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: clear-sandbox
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/clear_sandbox.sh
   schedule: '0 */12 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: auto-create-pages-6h
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/auto_create_pages_6h.sh
   schedule: '0 */6 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: requests-raed
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/requests_read.sh
   schedule: '*/5 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: requests-load
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/requests_load.sh
   schedule: '*/10 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: requests-run
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/requests_run.sh
   schedule: '*/15 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: read-new-page-20
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/read.sh
   schedule: '*/20 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: maintenance-check-10
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/maintenance_check.sh
   #  schedule: '*/10 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   continuous: true
   <<: *defaults
@@ -91,7 +91,7 @@
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/webcite_check.sh
   #  schedule: '*/10 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   continuous: true
   <<: *defaults
@@ -100,7 +100,7 @@
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/read_last_day.sh 1540
   schedule: '10 0 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 
@@ -108,7 +108,15 @@
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/month_statistics.sh
   schedule: '5 0 * * *'
-  image: tf-python39
+  image: python3.13
+  emails: onfailure
+  <<: *defaults
+
+- name: archive-bot
+  no-filelog: false
+  command: $HOME/repos/toolforge/jobs/archive_bot.sh
+  schedule: '0 6 * * *'
+  image: python3.13
   emails: onfailure
   <<: *defaults
 

--- a/toolforge/cronjobs1.yaml
+++ b/toolforge/cronjobs1.yaml
@@ -2,19 +2,19 @@
   name: dummy-defaults-job
   command: echo this is a dummy job to set defaults
   emails: onfailure
-  image: tf-python39
+  image: python3.13
   no-filelog: false
 - name: test-pull
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/ci_cd_log_task.sh
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: maintenance-check-10
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/maintenance_check.sh
   #  schedule: '*/10 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   continuous: true
   <<: *defaults
@@ -22,7 +22,7 @@
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/webcite_check.sh
   #  schedule: '*/10 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   continuous: true
   <<: *defaults
@@ -30,27 +30,27 @@
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/read.sh
   schedule: '*/20 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: webcite-24h
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/read_last_day.sh 1540
   schedule: '10 0 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
-- name: php-archive-bot
+- name: archive-bot
   no-filelog: false
-  command: $HOME/repos/toolforge/jobs/php_archive_bot.sh
+  command: $HOME/repos/toolforge/jobs/archive_bot.sh
   schedule: '0 6 * * *'
-  image: php7.4
+  image: python3.13
   emails: onfailure
   
 - name: photo-lab
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/photo_lab.sh
   schedule: '0 6 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults

--- a/toolforge/cronjobs2.yaml
+++ b/toolforge/cronjobs2.yaml
@@ -2,88 +2,88 @@
   name: dummy-defaults-job
   command: echo this is a dummy job to set defaults
   emails: onfailure
-  image: tf-python39
+  image: python3.13
   no-filelog: false
 - name: test-pull
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/ci_cd_log_task.sh
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: statistics-daily
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/statistics-daily.sh
   schedule: '0 1 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: statistics-weekly
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/statistics-weekly.sh
   schedule: '0 2 * * 1'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: missingtopics
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/missingtopics.sh
   schedule: '0 2 * * 1'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: utw-daily
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/users_this_week-daily.sh
   schedule: '0 2 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: utw-weekly
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/users_this_week-weekly.sh
   schedule: '0 2 * * 1'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: clear-sandbox
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/clear_sandbox.sh
   schedule: '0 */12 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: auto-create-pages-6h
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/auto_create_pages_6h.sh
   schedule: '0 */6 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: requests-raed
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/requests_read.sh
   schedule: '*/5 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: requests-load
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/requests_load.sh
   schedule: '*/10 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: requests-run
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/requests_run.sh
   schedule: '*/15 * * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults
 - name: month-statistics
   no-filelog: false
   command: $HOME/repos/toolforge/jobs/month_statistics.sh
   schedule: '5 0 * * *'
-  image: tf-python39
+  image: python3.13
   emails: onfailure
   <<: *defaults

--- a/toolforge/jobs/archive_bot.sh
+++ b/toolforge/jobs/archive_bot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#set -euo pipefail
+
+. "$HOME"/repos/.venvs/lokas-bot-scripts/bin/activate
+
+export PYWIKIBOT_DIR="$HOME/repos"
+
+export PYTHONPATH="${PYTHONPATH}:$HOME/repos"
+
+
+python3  "$HOME"/repos/tasks/archive_bot/main.py
+
+# Exit the script after running all the Python files
+exit 0


### PR DESCRIPTION
## Summary
Migrate the legacy **PHP archivebot** (Peachy, https://github.com/LokasWiki/archivebot) into a Python task in LokasBot, running on pywikibot + Python 3.13.

This PR currently contains the **migration plan + TODO checklist** (`tasks/archive_bot/PLAN.md`). Implementation will follow in this branch.

## What the bot does
Archives old discussion threads from Arabic Wikipedia **user talk pages** (namespace 3) that transclude `{{أرشفة آلية}}`.

## TODO checklist (from PLAN.md)
- [x] Phase A — package + test scaffolding
- [x] Phase B — pure domain logic (section splitter, template parser, archive-decision engine)
- [x] Phase C — pywikibot infrastructure (repository + wiring)
- [x] Phase D — orchestration (`archive_page` use case + `main.py`)
- [x] Phase E — unit + integration tests
- [x] Phase F — config loader + README
- [x] Phase G — Toolforge job + cron wiring (after local validation)

Full detail in `tasks/archive_bot/PLAN.md`.